### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Included with this library there are a NSColor/UIColor initializer for convertin
 
 In the *Script* folder there is a script written in python which can be used to parse the Google website linked above and produce a list of struct with colors. It's manly for internal use but feel free to do whatever you want with it. (*Note: Text colors are taken from css file*)
 
-###Usage
+### Usage
 
 	// iOS
 	var myColor = UIColor(rgba: MaterialColors.Red.P500.HUE))
@@ -20,9 +20,9 @@ In the *Script* folder there is a script written in python which can be used to 
 	var myColor = NSColor(rgba: MaterialColors.Red.P500.HUE))
 	var myTextColor = NSColor(rgba: MaterialColors.Red.P500.TEXT))
 
-###Note
+### Note
 
 This library is written in Swift and (should be) compatible with OSX and iOS development but I am not using Yosemite yet so feedbacks are welcome.
 
-###License
+### License
 This code is distributed under the terms and conditions of the [MIT license](LICENSE). 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
